### PR TITLE
Expose jsmart settings in jsmart-express

### DIFF
--- a/jsmart-express.js
+++ b/jsmart-express.js
@@ -120,7 +120,7 @@ function render (templatePath, viewDirectory, viewExtension, options, cache, cal
       return partials[name]
     }
 
-    var smarty = new jSmart(template)
+    var smarty = new jSmart(template, options.settings['jsmart-settings'])
     callback(err, smarty.fetch(options))
   })
 }


### PR DESCRIPTION
Hi,

I need to use smarty templates with express which are using {{ and }} as delimiters instead of the standard { and }.

Reverse engineering your code, it seems that it is possible in jsmart but not in jsmart-express. 
This change exposes jsmart settings in jsmart-express.
This way, I can set custom jsmart settings even when using jsmart-express (I could find no other way).
Example:

	app.engine('tpl', jsmartExpress())

	app.set('view engine', 'tpl')
	app.set('views', viewDir)

	// testing custom options
	app.set('jsmart-settings', {
		'ldelim': '{{',
		'rdelim': '}}'
	})
